### PR TITLE
updated android package name to avoid conflicts

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -82,7 +82,7 @@ def configureReactNativePom(def pom) {
         name packageJson.title
         artifactId packageJson.name
         version = packageJson.version
-        group = "com.reactlibrary"
+        group = "com.nielsotten.rnismuted"
         description packageJson.description
         url packageJson.repository.baseUrl
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary">
+          package="com.nielsotten.rnismuted">
 
 </manifest>

--- a/android/src/main/java/com/reactlibrary/IsMutedModule.java
+++ b/android/src/main/java/com/reactlibrary/IsMutedModule.java
@@ -1,4 +1,4 @@
-package com.reactlibrary;
+package com.nielsotten.rnismuted;
 
 import android.content.Context;
 import android.media.AudioManager;

--- a/android/src/main/java/com/reactlibrary/IsMutedPackage.java
+++ b/android/src/main/java/com/reactlibrary/IsMutedPackage.java
@@ -1,4 +1,4 @@
-package com.reactlibrary;
+package com.nielsotten.rnismuted;
 
 import java.util.Arrays;
 import java.util.Collections;


### PR DESCRIPTION
It looks like we experienced a naming collision while building the app:

```
[18:45:25]: ▸ > Task :app:transformClassesAndResourcesWithR8ForMasterRelease FAILED
[18:45:25]: ▸ R8: Program type already present: com.reactlibrary.BuildConfig
[18:45:25]: ▸ FAILURE: Build failed with an exception.
[18:45:25]: ▸ * What went wrong:
[18:45:25]: ▸ Execution failed for task ':app:transformClassesAndResourcesWithR8ForMasterRelease'.
[18:45:25]: ▸ > com.android.tools.r8.CompilationFailedException: Compilation failed to complete
```

Others might have experienced a similar issue. This PR fixes it.